### PR TITLE
Added webpack 4 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,6 @@ module.exports = function(content) {
 
     jsonfromresx.convert(this.resourcePath, null, {}, function(result, err) {
         if(err) return callback(err);
-        callback(null, result);
+        callback(null, "module.exports = " + JSON.stringify(result) + ";");
     });
 };


### PR DESCRIPTION
I am quite new to webpack, so I don't know how it was before webpack v4, but all I know is that I couldn't make your code work with the new webpack : It expected a string or a buffer, while you returned an object.

I made this change to pack my resx file, but I have to admit that I didn't make much testing.

I hope this pull request can help, feel free to merge if it does or reject if I'm wrong.